### PR TITLE
Multiple plugin improvements: `executeImmediately`, `closePromptAfterExecute`, load plugins from directory instead of a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ GIT_TAG=0.0.8 make gh-release   # create release commit for given tag
 
 ## To-do / roadmap
 
+- Feat: `sacct` view should auto-refresh by appending to existing data
 - Feat: Support configuration using the config file rather than only args
   - Feat: Create a default config on first startup
 - Feat: `sacct` view further features: ability to search for jobs beyond currently loaded data, and/or ability to change time range within the view itself
 - Feat: `sstat` option for running jobs (returns tabular data, tbc how to do that nicely)
 - Feat: Summary stats in top middle pane: Node and job states
-- Feat: Ability to use `slurmrestd` / REST API instead of Slurm binaries
 - Feat: Config option for which view to start app in
 - Fix: `sacctmgr` views shared 1 sort column setting internally between views
 - Fix: highlight of currently selected row, if the cursor is on it, resets on data refresh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-3780-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-3810-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.
@@ -141,11 +141,23 @@ sudo mv ~/go/bin/stui /usr/local/bin
     ```yaml
     plugins:
       - name: Sstat a job
-        # Available pages: `nodes`, `jobs`, `sacctmgr`, `sacct`
+        # Available pages: `nodes`, `jobs`, `sacct`, `sacctmgr`
         activePage: jobs
         shortcut: "Ctrl-S"
         # Any column of a particular view can be used in a command template
-        command: sstat {{.JobId}}
+        command: sstat {{.JobId}} && ls -lah /dev
+        # Whether to execute command immediately rather than open a prompt. Default is false.
+        executeImmediately: true
+        # Closes prompt immediately once command is executed. Default is false.
+        # Only applies if `executeImmediately` is true.
+        closePromptAfterExecute: false
+    
+      - name: Open logs from a remote HTTP server
+        activePage: jobs
+        shortcut: "Ctrl-U"
+        command: firefox "https://localhost:8080/{{.JobId}}" > /dev/null &
+        executeImmediately: true
+        closePromptAfterExecute: true
     
       - name: Check node disk usage
         activePage: nodes

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-3845-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-3849-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-3810-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-3815-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.
@@ -109,6 +109,7 @@ sudo mv ~/go/bin/stui /usr/local/bin
     h/l      Scroll left/right in table view
     Arrows   Scroll up/down/left/right in table view
     ?        Show this help
+    Ctrl+R   Refresh currently visible data
     Ctrl+C   Exit
     o        Sort table by column
     

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-3815-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-3845-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.
@@ -60,8 +60,8 @@ sudo mv ~/go/bin/stui /usr/local/bin
     <!-- REPLACE_START -->
     ```txt
     Usage of ./stui:
-      -config-file string
-          path to config file for plugins, defaults to /home/$USER/.config/stui.yaml (default "/home/$USER/.config/stui.yaml")
+      -config-dir string
+          path to a directory with config files, defaults to /home/$USER/.config/stui.d/ (default "/home/$USER/.config/stui.d/")
       -copied-lines-separator string
           string to use when separating copied lines in clipboard (default "\n")
       -copy-first-column-only
@@ -131,12 +131,12 @@ sudo mv ~/go/bin/stui /usr/local/bin
     ```
     <!-- REPLACE_SHORTCUTS_END -->
 
-4. Configure custom plugins/shortcuts - configure `-config-file` argument or create a file in the default location `/home/$USER/.config/stui.yaml`:
+4. Configure custom plugins/shortcuts - configure `-config-dir` argument or create a `.yaml`/`.yml` file in the default location `/home/$USER/.config/stui.d./`. Files are processed in alphabetical order. Please note that plugin configs are **concatenated**, not merged.
 
-    - Full list of available keys are [here](https://github.com/gdamore/tcell/blob/781586687ddb57c9d44727dc9320340c4d049b11/key.go#L83-L202)
+    - Full list of available keybinds can be found [here](https://github.com/gdamore/tcell/blob/781586687ddb57c9d44727dc9320340c4d049b11/key.go#L83-L202).
     - If several keybinds match, first plugin defined for that page takes priority.
-    - Plugins are processed last, they cannot override existing keybinds.
-    - Any column in a given table view is available for use, following standard [Go template](https://pkg.go.dev/text/template) syntax
+    - Plugins are processed after existing keybinds, and cannot override the defaults.
+    - Any column in a given table view is available for use, following standard [Go template](https://pkg.go.dev/text/template) syntax.
 
     <!-- REPLACE_CONFIG_EXAMPLE_START -->
     ```yaml
@@ -146,7 +146,7 @@ sudo mv ~/go/bin/stui /usr/local/bin
         activePage: jobs
         shortcut: "Ctrl-S"
         # Any column of a particular view can be used in a command template
-        command: sstat {{.JobId}} && ls -lah /dev
+        command: sstat {{.JobId}}
         # Whether to execute command immediately rather than open a prompt. Default is false.
         executeImmediately: true
         # Closes prompt immediately once command is executed. Default is false.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ var (
 	PartitionFilter        string        = ""
 	LogLevel               int           = 2
 	ShowAllColumns         bool          = false
-	ConfigFilePath         string        = DEFAULT_CONFIG_LOCATION
+	ConfigDirPath          string        = DEFAULT_CONFIG_LOCATION
 
 	// Raw config options are not exposed to other modules, but pre-parsed by the config module
 	rawNodeViewColumns  string = "CPULoad//CPUAlloc//CPUTot,AllocMem//RealMemory,CfgTRES,Reason,Boards"
@@ -108,7 +108,7 @@ e        Focus on Entity type selector, 'esc' to close
 	// Misc
 	ALL_CATEGORIES_OPTION   = "(all)"
 	NO_SORT_OPTION          = "(no sort)"
-	DEFAULT_CONFIG_LOCATION = "/home/$USER/.config/stui.yaml"
+	DEFAULT_CONFIG_LOCATION = "/home/$USER/.config/stui.d/"
 )
 
 func Configure() {
@@ -121,7 +121,7 @@ func Configure() {
 	flag.StringVar(&rawJobViewColumns, "job-columns-config", rawJobViewColumns, "comma-separated list of scontrol fields to show in job view, use '//' to combine columns. 'JobId', 'Partitions' and 'JobState' are always shown.")
 	flag.StringVar(&rawSacctViewColumns, "sacct-columns-config", rawSacctViewColumns, "comma-separated list of sacct fields to show in job view, use '//' to combine columns. 'JobIDRaw', 'Partitions' and 'State' are always shown.")
 	flag.StringVar(&PartitionFilter, "partition", PartitionFilter, "limit views to specific partition only, leave empty to show all partitions")
-	flag.StringVar(&ConfigFilePath, "config-file", ConfigFilePath, "path to config file for plugins, defaults to /home/$USER/.config/stui.yaml")
+	flag.StringVar(&ConfigDirPath, "config-dir", ConfigDirPath, "path to a directory with config files, defaults to /home/$USER/.config/stui.d/")
 	flag.BoolVar(&CopyFirstColumnOnly, "copy-first-column-only", CopyFirstColumnOnly, "if true, only copy the first column of the table to clipboard when copying")
 	flag.BoolVar(&ShowAllColumns, "show-all-columns", ShowAllColumns, "if set, shows all columns for Nodes, Jobs and Accounting view Jobs, overriding other specific config")
 	flag.IntVar(&LogLevel, "log-level", LogLevel, "log level, 0=none, 1=error, 2=info, 3=debug")
@@ -132,17 +132,17 @@ func Configure() {
 	// flag.DurationVar(&SearchDebounceInterval, "search-debounce-interval", SearchDebounceInterval, "interval to wait before searching, specify as a duration e.g. '300ms', '1s', '2m'")
 
 	// Load config file if it exists
-	if ConfigFilePath == DEFAULT_CONFIG_LOCATION {
+	if ConfigDirPath == DEFAULT_CONFIG_LOCATION {
 		user, _ := user.Current()
-		ConfigFilePath = fmt.Sprintf(
-			"%s/.config/stui.yaml",
+		ConfigDirPath = fmt.Sprintf(
+			"%s/.config/stui.d/",
 			user.HomeDir,
 		)
 	}
-	if _, err := os.Stat(ConfigFilePath); err != nil {
+	if _, err := os.Stat(ConfigDirPath); err != nil {
 		// No need to print a message as configuration file is NOT mandatory.
 	} else {
-		ConfigFile = LoadConfig(ConfigFilePath)
+		ConfigFile = LoadConfigsFromDir(ConfigDirPath)
 	}
 
 	// One-shot-and-exit flags

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ k/j      Move selection up/down in table view
 h/l      Scroll left/right in table view
 Arrows   Scroll up/down/left/right in table view
 ?        Show this help
+Ctrl+R   Refresh currently visible data
 Ctrl+C   Exit
 o        Sort table by column
 

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -8,10 +8,12 @@ import (
 )
 
 type PluginConfig struct {
-	Name       string `yaml:"name"`
-	ActivePage string `yaml:"activePage"`
-	Shortcut   string `yaml:"shortcut"`
-	Command    string `yaml:"command"`
+	Name                    string `yaml:"name"`
+	ActivePage              string `yaml:"activePage"`
+	Shortcut                string `yaml:"shortcut"`
+	Command                 string `yaml:"command"`
+	ExecuteImmediately      bool   `yaml:"executeImmediately"`
+	ClosePromptAfterExecute bool   `yaml:"closePromptAfterExecute"`
 }
 
 type Config struct {

--- a/internal/view/commandmodal.go
+++ b/internal/view/commandmodal.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (a *App) executeCommand(input *tview.InputField, output *tview.TextView, cmdText string, pageName string) {
-	output.SetText("Executing: " + cmdText + "\n\n")
+	output.SetText("\n\n")
 
 	// Execute command
 	ctx, cancel := context.WithTimeout(context.Background(), config.RequestTimeout)
@@ -57,6 +57,10 @@ func (a *App) ShowCommandModal(command string, pageName string, executeImmediate
 		SetText(command).
 		SetFieldWidth(0)
 
+	if executeImmediately {
+		input.SetDisabled(true)
+	}
+
 	// Create output view
 	output := tview.NewTextView().
 		SetDynamicColors(true).
@@ -81,12 +85,12 @@ func (a *App) ShowCommandModal(command string, pageName string, executeImmediate
 		SetBorderColor(modalBorderColor).
 		SetBackgroundColor(generalBackgroundColor)
 
-	// Center the modal
+	// Create centered container with fixed size (80% width, 90% height)
 	centered := tview.NewFlex().
 		AddItem(nil, 0, 1, false).
 		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(modal, 25, 1, true),
-			0, 60, false).
+			AddItem(modal, 0, 10, true),
+			0, 16, false).
 		AddItem(nil, 0, 1, false)
 
 	// Store current page before showing modal

--- a/internal/view/keybinds.go
+++ b/internal/view/keybinds.go
@@ -335,6 +335,10 @@ func tableViewInputCapture(
 				detailsFunction(entryName)
 				return nil
 			}
+		case tcell.KeyCtrlR:
+			// Manual refresh of currently visible view
+			a.optionalRefreshAndRenderCurrentView(true)
+			a.ShowNotification("[green]Ctrl+R: Manual data refresh[white]", 1*time.Second)
 		case tcell.KeyCtrlD:
 			// The below is an ugly way to check that we're in the jobs view
 			if strings.Contains(commandModalFilter, "JobId") {

--- a/internal/view/plugins.go
+++ b/internal/view/plugins.go
@@ -24,8 +24,6 @@ func (a *App) ExecutePluginForShortcut(key tcell.Key, page string, rowId string)
 			continue // The key is invalid so we skip this plugin
 		}
 
-		// First plugin takes precedence if there's many defined for the
-		// same shortcut.
 		if parsedKey == key {
 			provider := a.GetProviderForPage(page)
 			if provider == nil {
@@ -41,7 +39,9 @@ func (a *App) ExecutePluginForShortcut(key tcell.Key, page string, rowId string)
 
 			parsedCommand := a.ParsePluginCommand(plugin.Command, rowData, page)
 
-			a.ShowCommandModal(parsedCommand, page)
+			a.ShowCommandModal(parsedCommand, page, plugin.ExecuteImmediately, plugin.ClosePromptAfterExecute)
+
+			// Stop processing further plugins - first one takes precedence.
 			break
 		}
 	}

--- a/makefile
+++ b/makefile
@@ -8,7 +8,8 @@ setup:
 	sudo useradd johndoe -u 1337 -g 1337 -m -s /bin/bash
 
 setup-config-if-missing:
-	stat /home/$$USER/.config/stui.yaml > /dev/null || ln -s $$(pwd)/testing/example-stui-config.yaml $$HOME/.config/stui.yaml
+	mkdir -p /home/$$USER/.config/stui.d/
+	stat /home/$$USER/.config/stui.d/example.yaml > /dev/null || ln -s $$(pwd)/testing/example-stui-config.yaml /home/$$USER/.config/stui.d/example.yaml
 
 lint: setup-config-if-missing
 	find -name "*.go" | xargs -I{} go fmt {}

--- a/testing/example-stui-config.yaml
+++ b/testing/example-stui-config.yaml
@@ -1,10 +1,22 @@
 plugins:
   - name: Sstat a job
-    # Available pages: `nodes`, `jobs`, `sacctmgr`, `sacct`
+    # Available pages: `nodes`, `jobs`, `sacct`, `sacctmgr`
     activePage: jobs
     shortcut: "Ctrl-S"
     # Any column of a particular view can be used in a command template
     command: sstat {{.JobId}}
+    # Whether to execute command immediately rather than open a prompt. Default is false.
+    executeImmediately: true
+    # Closes prompt immediately once command is executed. Default is false.
+    # Only applies if `executeImmediately` is true.
+    closePromptAfterExecute: false
+
+  - name: Open logs from a remote HTTP server
+    activePage: jobs
+    shortcut: "Ctrl-U"
+    command: firefox "https://localhost:8080/{{.JobId}}" > /dev/null &
+    executeImmediately: true
+    closePromptAfterExecute: true
 
   - name: Check node disk usage
     activePage: nodes


### PR DESCRIPTION
- `executeImmediately` allows safe commands to be triggered immediately rather than always requiring the user to press enter. This can be coupled with `closePromptAfterExecute` to do 'fire-and-forget' type commands where the output doesn't matter, for example to open links to external logging/metrics services.
- `Ctrl+R` to refresh currently active view
- Load plugins from a directory, allowing for layered configs