### PR TITLE
feat(commands): clear selection within current view if the command was successful

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-3863-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-3876-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/internal/view/app_helpers.go
+++ b/internal/view/app_helpers.go
@@ -31,6 +31,13 @@ func (a *App) GetCurrentStuiView() *StuiView {
 	}
 }
 
+func (a *App) ClearSelectionFromCurrentView() {
+	view := a.GetCurrentStuiView()
+	if view != nil {
+		view.Selection = map[string]bool{}
+	}
+}
+
 func (a *App) GetProviderForPage(page string) model.DataProvider[*model.TableData] {
 	switch page {
 	case NODES_PAGE:

--- a/internal/view/commandmodal.go
+++ b/internal/view/commandmodal.go
@@ -31,8 +31,14 @@ func (a *App) executeCommand(output *tview.TextView, cmdText string, pageName st
 		} else {
 			output.SetText(output.GetText(true) + commandOutput)
 		}
-		// Trigger table refresh in the background after a successful command
+
+		// After a successful command...
+		// ... clear the user's selection within the current view
+		a.ClearSelectionFromCurrentView()
+
+		// ... and trigger a table view refresh in the background
 		a.RefreshAndRenderPage(pageName)
+
 	}
 }
 


### PR DESCRIPTION
This prevents issues where you may have a filter applied to your view, select a few entries, and then run a command - at this point your command may change what rows you see, but previously the selection wouldn't be reset. Executing another command at this point could then target rows that you no longer see (=and probably no longer want to target).


Closes https://github.com/Antvirf/stui/issues/9