### PR TITLE
feat(sacct): version-aware full-columns list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-4055-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-4065-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - View individual node details (`scontrol show node` equivalent)
 - View individual job details (`scontrol show job` equivalent)
 - Show `sdiag` output for scheduler diagnostics
-- (if Slurm accounting is enabled) Explore historical job accounting from `sacct` tables, search across rows with regular expressions, filtering by partition and state. This view is not refreshed automatically.
+- (if Slurm accounting is enabled) Explore historical job accounting from `sacct` tables, search across rows with regular expressions, filtering by partition and state. View individual job details (`sacct -j` equivalent, with all available columns)
 - (if Slurm accounting is enabled) Explore `sacctmgr` tables, search across rows with regular expressions
 - Configure table views with specific columns/content of your choice
 - Optimized to minimize load on the Slurm scheduler by only fetching the data user is looking at. Default configs make ~1 request per minute after initial startup.


### PR DESCRIPTION
Closes https://github.com/Antvirf/stui/issues/28

`sacct` is more sensitive when it comes to prompts asking for outputs that are not available. This resulted in the `sacct` detail view not working on older clusters (23.11). This PR ensures that 23.11 clusters get a column list that is compatible with them.

This change also implies that `stui` may not be fully compatible (in that not all features will work) on older clusters.