### PR TITLE
fix/39/job name parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-4367-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-4377-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/internal/model/parsers.go
+++ b/internal/model/parsers.go
@@ -112,7 +112,18 @@ func parseScontrolJobsOutput(output string) (jobs []map[string]string) {
 				}
 			}
 
-			// Special case handling
+			// Special case handling: First line with just JobID and JobName
+			// This needs special handling as JobName may have spaces, e..g
+			// JobId=600 JobName=job general 2
+			// Our check for this line uses hardcoded keys, hence the code block does too.
+			if strings.Contains(line, "JobId=") && strings.Contains(line, "JobName=") {
+				firstSpace := strings.Index(line, " ")
+				currentJob["JobId"] = strings.Split(line[:firstSpace], "=")[1]
+				currentJob["JobName"] = strings.Split(line[firstSpace+1:], "=")[1]
+				continue
+			}
+
+			// Special case handling: Fields on a single line
 			if isSingleFieldLine {
 				// Split by the first =
 				if idx := strings.Index(line, "="); idx > 0 {

--- a/testing/test-job-launcher.sh
+++ b/testing/test-job-launcher.sh
@@ -5,6 +5,6 @@ for NUMBER in {1..15}; do
         MEMORY=$(( (RANDOM % 64) + 1 ))
 
         cat testing/mock-cluster-slurmconf.conf  | grep PartitionName | cut -d= -f2 | cut -d' ' -f1 | \
-            xargs -I{} sbatch --partition={} --uid 1337 --job-name=job-{}-$NUMBER --comment="this is a multi word comment of job-{}-$NUMBER" --mem="$MEMORY"G  --cpus-per-task=$CPUS --qos=$QOS --out=/dev/null testing/sleep.sh "$NUMBER"
+            xargs -I{} sbatch --partition={} --uid 1337 --job-name="job {} $NUMBER" --comment="this is a multi word comment of job-{}-$NUMBER" --mem="$MEMORY"G  --cpus-per-task=$CPUS --qos=$QOS --out=/dev/null testing/sleep.sh "$NUMBER"
     done
 done


### PR DESCRIPTION
- **feat(selectors: add `Ctrl+A` (all) and `Ctrl+I` (invert) selection shortcuts**
- **fix(scontrol-jobs): correctly parse job name even if it has whitespaces**
