### PR TITLE
feat(selectors: add `Ctrl+A` (all) and `Ctrl+I` (invert) selection shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-4380-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-4367-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-4295-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-4380-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E4M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.
@@ -109,6 +109,8 @@ sudo mv ~/go/bin/stui /usr/local/bin
     h/l      Scroll left/right in table view
     Arrows   Scroll up/down/left/right in table view
     ?        Show this help
+    Ctrl+A   Select all currently filtered rows
+    Ctrl+I   Invert selection within filtered rows
     Ctrl+R   Refresh currently visible data
     Ctrl+C   Exit
     o        Sort table by column

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,8 @@ k/j      Move selection up/down in table view
 h/l      Scroll left/right in table view
 Arrows   Scroll up/down/left/right in table view
 ?        Show this help
+Ctrl+A   Select all currently filtered rows
+Ctrl+I   Invert selection within filtered rows
 Ctrl+R   Refresh currently visible data
 Ctrl+C   Exit
 o        Sort table by column

--- a/internal/view/keybinds.go
+++ b/internal/view/keybinds.go
@@ -421,7 +421,6 @@ func selectRow(a *App, view *tview.Table, rowIndex int, selection *map[string]bo
 	entryName := strings.TrimSpace(view.GetCell(rowIndex, 0).Text)
 
 	if (*selection)[entryName] && !additionalSelectOnly {
-		//delete(*selection, entryName)
 		(*selection)[entryName] = false
 
 		// Check whether we should give this row a special color based on its state field

--- a/internal/view/keybinds.go
+++ b/internal/view/keybinds.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -224,45 +225,11 @@ func tableViewInputCapture(
 			return nil
 		case ' ':
 			row, _ := view.GetSelection()
-			// Certain tables in Sacctmgr have no clear ID, and the current selection implementation relies
-			// on the first column of a row to be an identifier column.
-			if view == a.SacctMgrView.Table &&
-				slices.Contains(
-					model.SACCTMGR_ENTITY_TABLES_WITH_NO_CLEAR_ID,
-					config.SacctMgrCurrentEntity,
-				) {
-				return nil
-			}
-			if row > 0 { // Skip header row
-				entryName := view.GetCell(row, 0).Text
-
-				if (*selection)[entryName] {
-					delete(*selection, entryName)
-
-					// Check whether we should give this row a special color based on its state field
-					stateText := view.GetCell(row, config.NodeViewColumnsStateIndex).Text
-					colorizedColor, shouldColorizeRow := GetStateColorMapping(stateText)
-
-					for col := 0; col < view.GetColumnCount(); col++ {
-						cell := view.GetCell(row, col)
-						cell.SetBackgroundColor(generalBackgroundColor).
-							SetSelectedStyle(tcell.StyleDefault.Background(rowCursorColorBackground))
-						if shouldColorizeRow {
-							cell.SetTextColor(colorizedColor)
-						} else {
-							cell.SetTextColor(generalTextColor)
-						}
-					}
-				} else {
-					(*selection)[entryName] = true
-					for col := 0; col < view.GetColumnCount(); col++ {
-						view.GetCell(row, col).
-							SetBackgroundColor(selectionColor).
-							SetTextColor(selectionTextColor).
-							SetSelectedStyle(tcell.StyleDefault.Background(selectionHighlightColor))
-					}
-				}
-			}
+			selectRow(a, view, row, selection, data.Length(), false)
+			// Hacky way to update selection counter immediately
+			a.PagesContainer.SetTitle(
+				hackyUpdateTitleWithSelectionCount(a.PagesContainer.GetTitle(), selection),
+			)
 			return nil
 		case 'p':
 			if a.GetCurrentPageName() == JOBS_PAGE || a.GetCurrentPageName() == NODES_PAGE || a.GetCurrentPageName() == SACCT_PAGE {
@@ -331,6 +298,29 @@ func tableViewInputCapture(
 		}
 
 		switch event.Key() {
+		case tcell.KeyCtrlA:
+			rows := view.GetRowCount()
+			for rowIndex := 1; rowIndex < rows; rowIndex++ {
+				selectRow(a, view, rowIndex, selection, data.Length(), true)
+			}
+			a.ShowNotification("[green]Ctrl+A: Select all visible rows[white]", 2*time.Second)
+
+			// Hacky way to update selection counter immediately
+			a.PagesContainer.SetTitle(
+				hackyUpdateTitleWithSelectionCount(a.PagesContainer.GetTitle(), selection),
+			)
+
+			return nil
+		case tcell.KeyCtrlI:
+			rows := view.GetRowCount()
+			for rowIndex := 1; rowIndex < rows; rowIndex++ {
+				selectRow(a, view, rowIndex, selection, data.Length(), false)
+			}
+			// Hacky way to update selection counter immediately
+			a.PagesContainer.SetTitle(
+				hackyUpdateTitleWithSelectionCount(a.PagesContainer.GetTitle(), selection),
+			)
+			a.ShowNotification("[green]Ctrl+I: Invert selection[white]", 2*time.Second)
 		case tcell.KeyEnter:
 			row, _ := view.GetSelection()
 			if row > 0 { // Skip header row
@@ -341,7 +331,7 @@ func tableViewInputCapture(
 		case tcell.KeyCtrlR:
 			// Manual refresh of currently visible view
 			a.optionalRefreshAndRenderCurrentView(true)
-			a.ShowNotification("[green]Ctrl+R: Manual data refresh[white]", 1*time.Second)
+			a.ShowNotification("[green]Ctrl+R: Manual data refresh[white]", 2*time.Second)
 		case tcell.KeyCtrlD:
 			row, _ := view.GetSelection()
 			if row == 0 { // Skip if user is on header row / there is on data
@@ -381,5 +371,80 @@ func tableViewInputCapture(
 			}
 		}
 		return event
+	}
+}
+
+// This is a mega ugly way to do it. Some longer term refactoring needed here
+// to async share messages between components.
+func hackyUpdateTitleWithSelectionCount(title string, selection *map[string]bool) string {
+	selectionCount := getSelectionCount(selection)
+
+	// If it already contains '| %d selected', remove it
+	re := regexp.MustCompile(`\|\s.*`)
+	title = re.ReplaceAllString(title, "")
+
+	if selectionCount == 0 {
+		return title
+	}
+	return fmt.Sprintf("%s| %s selected", title, FormatNumberWithCommas(selectionCount))
+}
+
+func getSelectionCount(selection *map[string]bool) (count int) {
+	for key, _ := range *selection {
+		if (*selection)[key] {
+			count += 1
+		}
+	}
+	return
+}
+
+func selectRow(a *App, view *tview.Table, rowIndex int, selection *map[string]bool, dataLength int, additionalSelectOnly bool) {
+	// Certain tables in Sacctmgr have no clear ID, and the current selection implementation relies
+	// on the first column of a row to be an identifier column.
+	if view == a.SacctMgrView.Table &&
+		slices.Contains(
+			model.SACCTMGR_ENTITY_TABLES_WITH_NO_CLEAR_ID,
+			config.SacctMgrCurrentEntity,
+		) {
+		return
+	}
+
+	if rowIndex <= 0 { // Skip header and -ve rows
+		return
+	}
+
+	if dataLength <= 1 { // header row does not count
+		return
+	}
+
+	// Cells can be padded for width/alignment reasons, hence we have to trim.
+	entryName := strings.TrimSpace(view.GetCell(rowIndex, 0).Text)
+
+	if (*selection)[entryName] && !additionalSelectOnly {
+		//delete(*selection, entryName)
+		(*selection)[entryName] = false
+
+		// Check whether we should give this row a special color based on its state field
+		stateText := view.GetCell(rowIndex, config.NodeViewColumnsStateIndex).Text
+		colorizedColor, shouldColorizeRow := GetStateColorMapping(stateText)
+
+		for col := 0; col < view.GetColumnCount(); col++ {
+			cell := view.GetCell(rowIndex, col)
+			cell.SetBackgroundColor(generalBackgroundColor).
+				SetSelectedStyle(tcell.StyleDefault.Background(rowCursorColorBackground))
+			if shouldColorizeRow {
+				cell.SetTextColor(colorizedColor)
+			} else {
+				cell.SetTextColor(generalTextColor)
+			}
+		}
+	} else {
+		(*selection)[entryName] = true
+		for col := 0; col < view.GetColumnCount(); col++ {
+			view.GetCell(rowIndex, col).
+				SetBackgroundColor(selectionColor).
+				SetTextColor(selectionTextColor).
+				SetSelectedStyle(tcell.StyleDefault.Background(selectionHighlightColor))
+		}
 	}
 }

--- a/internal/view/stuiview.go
+++ b/internal/view/stuiview.go
@@ -73,6 +73,9 @@ type StuiViewInt interface {
 
 	// Updates data from provider and renders the view
 	FetchAndRender()
+
+	// Get active selection count
+	GetSelectionCount()
 }
 
 type StuiView struct {
@@ -108,6 +111,16 @@ func (s *StuiView) SetFilter(filter string) {
 
 func (s *StuiView) SetTitleHeader(v string) {
 	s.titleHeader = v
+}
+
+func (s *StuiView) GetSelectionCount() (count int) {
+	count = 0
+	for key, _ := range s.Selection {
+		if s.Selection[key] {
+			count += 1
+		}
+	}
+	return
 }
 
 func (s *StuiView) SetSearchEnabled(value bool) {
@@ -216,6 +229,7 @@ func (s *StuiView) Render() {
 			// Op 1: Text wrapping
 			colObject := (*s.data.Headers)[col]
 			// We need to *pad* the text here, as tview does not support a 'minimum width' parameter for tables.
+			// That is why we need to then trim the spaces later during selecting/deselecting rows.
 			cellView := tview.NewTableCell(fmt.Sprintf("%-*s", colObject.Width, cell)).
 				SetAlign(tview.AlignLeft).
 				SetExpansion(1)
@@ -269,6 +283,10 @@ func (s *StuiView) Render() {
 		FormatNumberWithCommas(filteredCount),
 		FormatNumberWithCommas(totalCount),
 	)
+	selectionCount := s.GetSelectionCount()
+	if selectionCount > 0 {
+		s.completeTitle += fmt.Sprintf("| %s selected", FormatNumberWithCommas(selectionCount))
+	}
 	s.updateTitleFunction(s.completeTitle)
 
 	lastUpdated := s.provider.LastUpdated()

--- a/internal/view/stuiview.go
+++ b/internal/view/stuiview.go
@@ -73,9 +73,6 @@ type StuiViewInt interface {
 
 	// Updates data from provider and renders the view
 	FetchAndRender()
-
-	// Get active selection count
-	GetSelectionCount()
 }
 
 type StuiView struct {
@@ -111,16 +108,6 @@ func (s *StuiView) SetFilter(filter string) {
 
 func (s *StuiView) SetTitleHeader(v string) {
 	s.titleHeader = v
-}
-
-func (s *StuiView) GetSelectionCount() (count int) {
-	count = 0
-	for key, _ := range s.Selection {
-		if s.Selection[key] {
-			count += 1
-		}
-	}
-	return
 }
 
 func (s *StuiView) SetSearchEnabled(value bool) {
@@ -283,7 +270,7 @@ func (s *StuiView) Render() {
 		FormatNumberWithCommas(filteredCount),
 		FormatNumberWithCommas(totalCount),
 	)
-	selectionCount := s.GetSelectionCount()
+	selectionCount := getSelectionCount(&s.Selection)
 	if selectionCount > 0 {
 		s.completeTitle += fmt.Sprintf("| %s selected", FormatNumberWithCommas(selectionCount))
 	}


### PR DESCRIPTION
Also adds '| %d selected' to the title bar. This is done in a rather
ugly and code-repeating way, lots of room here to refactor towards some
central notification/text sharing channel. Regex filter works
differently as it has to render a new table every time - the selector
does not, and I did not want to induce a full render on every select
either just to keep the code simpler. Instead there should be some
better way to send that info between components, likely a central
notifications channel. TBC.
