### PR TITLE
minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-7431-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-7440-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E8M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo mv ~/go/bin/stui /usr/local/bin
     Arrows   Scroll up/down/left/right in table view
     ?        Show this help
     Ctrl+A   Select all currently filtered rows
-    Ctrl+I   Invert selection within filtered rows
+    Ctrl+N   Invert selection within filtered rows
     Ctrl+R   Refresh currently visible data
     Ctrl+S   Export current view as CSV file
     Ctrl+C   Exit

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,7 @@ h/l      Scroll left/right in table view
 Arrows   Scroll up/down/left/right in table view
 ?        Show this help
 Ctrl+A   Select all currently filtered rows
-Ctrl+I   Invert selection within filtered rows
+Ctrl+N   Invert selection within filtered rows
 Ctrl+R   Refresh currently visible data
 Ctrl+S   Export current view as CSV file
 Ctrl+C   Exit

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -26,6 +26,14 @@ func EmptyTableData() *TableData {
 	}
 }
 
+func EmptyTableDataWithColumns(columns *[]config.ColumnConfig) *TableData {
+	return &TableData{
+		Headers:             columns,
+		Rows:                [][]CellValue{},
+		RowsAsSingleStrings: []string{},
+	}
+}
+
 func convertRowsToRowsAsSingleStrings(rows [][]CellValue) []string {
 	rowsAsStrings := []string{}
 	for _, row := range rows {

--- a/internal/model/provider_jobs.go
+++ b/internal/model/provider_jobs.go
@@ -12,7 +12,7 @@ type JobsProvider struct {
 func NewJobsProvider(loadData bool) *JobsProvider {
 	p := JobsProvider{
 		BaseProvider: BaseProvider[*TableData]{
-			data: EmptyTableData(),
+			data: EmptyTableDataWithColumns(config.JobViewColumns),
 		},
 	}
 	if loadData {

--- a/internal/model/provider_nodes.go
+++ b/internal/model/provider_nodes.go
@@ -13,7 +13,7 @@ type NodesProvider struct {
 func NewNodesProvider(loadData bool) *NodesProvider {
 	p := NodesProvider{
 		BaseProvider: BaseProvider[*TableData]{
-			data: EmptyTableData(),
+			data: EmptyTableDataWithColumns(config.NodeViewColumns),
 		},
 	}
 	if loadData {

--- a/internal/model/provider_sacct.go
+++ b/internal/model/provider_sacct.go
@@ -13,7 +13,7 @@ type SacctProvider struct {
 func NewSacctProvider(loadData bool) *SacctProvider {
 	p := SacctProvider{
 		BaseProvider: BaseProvider[*TableData]{
-			data: EmptyTableData(),
+			data: EmptyTableDataWithColumns(config.SacctViewColumns),
 		},
 	}
 	if loadData {

--- a/internal/model/sacct_fetchers.go
+++ b/internal/model/sacct_fetchers.go
@@ -40,10 +40,10 @@ func getSacctDataSinceWithTimeout(since time.Duration, columns *[]config.ColumnC
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			logger.Debugf("sacct: timed out after %dms (its timeout setting is %d times the standard request timeout): %s", execTime, config.SacctTimeoutMultiplier, fullCommand)
-			return EmptyTableData(), fmt.Errorf("timeout after %v", timeout)
+			return EmptyTableDataWithColumns(columns), fmt.Errorf("timeout after %v", timeout)
 		}
 		logger.Debugf("sacct: failed out after %dms: %s", execTime, fullCommand)
-		return EmptyTableData(), fmt.Errorf("%v", timeout)
+		return EmptyTableDataWithColumns(columns), fmt.Errorf("%v", err)
 	}
 
 	logger.Debugf("sacct: completed in %dms: %s", execTime, fullCommand)
@@ -52,7 +52,7 @@ func getSacctDataSinceWithTimeout(since time.Duration, columns *[]config.ColumnC
 func parseSacctOutputToTableData(output string, columns *[]config.ColumnConfig, computeColumnWidths bool) (*TableData, error) {
 	rawRows := parseSacctOutput(output, SACCT_DELIMITER)
 	if len(rawRows) == 0 {
-		return EmptyTableData(), nil
+		return EmptyTableDataWithColumns(columns), nil
 	}
 
 	var rows [][]CellValue

--- a/internal/model/scontrol_fetchers_test.go
+++ b/internal/model/scontrol_fetchers_test.go
@@ -25,7 +25,7 @@ func TestNodesProvider(t *testing.T) {
 		{
 			name:            "with physics partition filter",
 			partitionFilter: "physics",
-			expectedCount:   100,
+			expectedCount:   101,
 		},
 		{
 			name:            "with non-existent partition filter",

--- a/internal/view/keybinds.go
+++ b/internal/view/keybinds.go
@@ -247,7 +247,7 @@ func tableViewInputCapture(
 			)
 
 			return nil
-		case tcell.KeyCtrlI:
+		case tcell.KeyCtrlN:
 			rows := view.GetRowCount()
 			for rowIndex := 1; rowIndex < rows; rowIndex++ {
 				selectRow(a, view, rowIndex, selection, data.Length(), false)
@@ -256,7 +256,7 @@ func tableViewInputCapture(
 			a.PagesContainer.SetTitle(
 				hackyUpdateTitleWithSelectionCount(a.PagesContainer.GetTitle(), selection),
 			)
-			a.ShowNotification("[green]Ctrl+I: Invert selection[white]", 2*time.Second)
+			a.ShowNotification("[green]Ctrl+N: Invert selection[white]", 2*time.Second)
 		case tcell.KeyEnter:
 			row, _ := view.GetSelection()
 			if row > 0 { // Skip header row

--- a/testing/mock-cluster-slurmconf.conf
+++ b/testing/mock-cluster-slurmconf.conf
@@ -39,12 +39,12 @@ NodeName=linux[1-8888] NodeHostName=localhost Port=[20001-28888] NodeAddr=127.0.
 
 # Partition configurations
 PartitionName=general    Nodes=ALL
-PartitionName=chemistry Nodes=linux[100-199]
-PartitionName=chem Nodes=linux101
-PartitionName=physics Nodes=linux[200-299]
-PartitionName=biology Nodes=linux[300-399]
-PartitionName=finance Nodes=linux[400-499]
-PartitionName=mathematics Nodes=linux[500-599]
-PartitionName=unallocated Nodes=linux[600-8888]
+PartitionName=chemistry Nodes=linux[100-199],linux1
+PartitionName=chem Nodes=linux101,linux2
+PartitionName=physics Nodes=linux[200-299],linux3
+PartitionName=biology Nodes=linux[300-399],linux4
+PartitionName=finance Nodes=linux[400-499],linux5
+PartitionName=mathematics Nodes=linux[500-599],linux6
+PartitionName=unallocated Nodes=linux[600-8888],linux7
 
 


### PR DESCRIPTION
- **fix: ensure sort dropdown is populated when quickstart option is in use**
  We initialize providers with `EmptyTableData`, which is a completely
  empty structure with no columns. Sort dropdown is a part of the static
  set of panels, and is 'set up' on page change, *before*
  FetchIfStaleAndRender takes place, which is why it was blank when
  switching to a new pane when using the `quickstart` launch option.
  
  With this fix, we instead instantiate jobs/nodes/sacct providers with
  the right columns, so that column data is available (this comes from
  configuration anyway, not dynamic!) to the provider by the time the sort
  dropdown is instantiated.
  

- **fix: change invert selection shortcut to Ctrl+N as Ctrl+I is often swallowed**
  

- **tooling: set partitions for first few fake nodes**
  This allows us to actually run all the different mock jobs instead of
  leaving in the queue.
  