### PR TITLE
various performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-7487-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-7788-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E8M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-7789-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-7791-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E8M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-7788-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-7789-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E8M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-7791-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-7909-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E8M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/internal/model/bench_test.go
+++ b/internal/model/bench_test.go
@@ -1,0 +1,148 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/antvirf/stui/internal/config"
+)
+
+// buildTableDataFromScontrolOutput constructs a *TableData from raw scontrol
+// one-liner output without executing an external command. It replicates the
+// column-building logic from getScontrolDataWithTimeout so that model-level
+// benchmarks can work offline using testdata files.
+func buildTableDataFromScontrolOutput(output string, columns *[]config.ColumnConfig) *TableData {
+	rawRows := parseScontrolOutput(output)
+	rows := make([][]CellValue, 0, len(rawRows))
+	for _, rawRow := range rawRows {
+		row := make([]CellValue, len(*columns))
+		for j := range *columns {
+			col := &(*columns)[j]
+			switch {
+			case col.ComputedColumn && col.ComputationType == "ratio":
+				components := strings.Split(col.RawName, "//")
+				if len(components) == 2 {
+					num := strings.TrimSpace(components[0])
+					den := strings.TrimSpace(components[1])
+					row[j] = NewRatioValue(
+						parseTypedValue(safeGetFromMap(rawRow, num), GetFieldType(num)),
+						parseTypedValue(safeGetFromMap(rawRow, den), GetFieldType(den)),
+					)
+				} else {
+					row[j] = NewStringValue("ERROR")
+				}
+			case col.DividedByColumn:
+				parts := strings.Split(col.RawName, "//")
+				vals := make([]string, len(parts))
+				for i, p := range parts {
+					vals[i] = safeGetFromMap(rawRow, p)
+				}
+				row[j] = parseTypedValue(strings.Join(vals, " / "), TypeString)
+			default:
+				row[j] = parseTypedValue(safeGetFromMap(rawRow, col.DisplayName), GetFieldType(col.DisplayName))
+			}
+		}
+		rows = append(rows, row)
+	}
+	return &TableData{
+		Headers:             columns,
+		Rows:                rows,
+		RowsAsSingleStrings: convertRowsToRowsAsSingleStrings(rows),
+	}
+}
+
+// BenchmarkParseScontrolOutput_Nodes measures parsing the full 8 888-node nodes.txt.
+func BenchmarkParseScontrolOutput_Nodes(b *testing.B) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "nodes.txt"))
+	if err != nil {
+		b.Fatalf("read nodes.txt: %v", err)
+	}
+	data := string(raw)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = parseScontrolOutput(data)
+	}
+}
+
+// BenchmarkParseScontrolOutput_Jobs measures parsing jobs.txt (630 jobs).
+func BenchmarkParseScontrolOutput_Jobs(b *testing.B) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "jobs.txt"))
+	if err != nil {
+		b.Fatalf("read jobs.txt: %v", err)
+	}
+	data := string(raw)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = parseScontrolOutput(data)
+	}
+}
+
+// BenchmarkApplyFilters_Nodes measures ApplyFilters with an all-pass filter
+// over the 8 888-node dataset (worst case: no rows dropped, all iterated).
+func BenchmarkApplyFilters_Nodes(b *testing.B) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "nodes.txt"))
+	if err != nil {
+		b.Fatalf("read nodes.txt: %v", err)
+	}
+	td := buildTableDataFromScontrolOutput(string(raw), config.NodeViewColumns)
+	filters := map[int]string{
+		config.NodeViewColumnsStateIndex:     config.ALL_CATEGORIES_OPTION,
+		config.NodeViewColumnsPartitionIndex: config.ALL_CATEGORIES_OPTION,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = td.ApplyFilters(filters)
+	}
+}
+
+// BenchmarkConvertRowsToSingleStrings measures the string-join step over 8 888 rows.
+func BenchmarkConvertRowsToSingleStrings(b *testing.B) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "nodes.txt"))
+	if err != nil {
+		b.Fatalf("read nodes.txt: %v", err)
+	}
+	td := buildTableDataFromScontrolOutput(string(raw), config.NodeViewColumns)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = convertRowsToRowsAsSingleStrings(td.Rows)
+	}
+}
+
+// BenchmarkDeepCopy_Nodes measures a full deep copy of a 8 888-row TableData.
+func BenchmarkDeepCopy_Nodes(b *testing.B) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "nodes.txt"))
+	if err != nil {
+		b.Fatalf("read nodes.txt: %v", err)
+	}
+	td := buildTableDataFromScontrolOutput(string(raw), config.NodeViewColumns)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = td.DeepCopy()
+	}
+}
+
+// BenchmarkApplyRegexSearchFilter measures regex compilation + row filtering over
+// the full 8 888-node RowsAsSingleStrings slice, matching the hot-path in
+// StuiView.ApplyRegexSearchFilterToRows.
+func BenchmarkApplyRegexSearchFilter(b *testing.B) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "nodes.txt"))
+	if err != nil {
+		b.Fatalf("read nodes.txt: %v", err)
+	}
+	td := buildTableDataFromScontrolOutput(string(raw), config.NodeViewColumns)
+	pattern := "(?i)IDLE"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		re, _ := regexp.Compile(pattern)
+		filteredRows := make([][]CellValue, 0, len(td.Rows)/2)
+		for j, s := range td.RowsAsSingleStrings {
+			if re.MatchString(s) {
+				filteredRows = append(filteredRows, td.Rows[j])
+			}
+		}
+		_ = filteredRows
+	}
+}

--- a/internal/model/constants.go
+++ b/internal/model/constants.go
@@ -22,6 +22,7 @@ var (
 		"MIX",
 		"MIXED",
 		"NO_RESPOND",
+		"NOT_RESPONDING",
 		"NPC",
 		"PERFCTRS",
 		"PLANNED",

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -118,8 +118,9 @@ var filterSplitRe = regexp.MustCompile("[,+]")
 // Applies a list of given filters to the data
 func (t *TableData) ApplyFilters(filters map[int]string) *TableData {
 	rows := make([][]CellValue, 0, len(t.Rows))
+	rowsAsSingleStrings := make([]string, 0, len(t.Rows))
 rowLoop:
-	for _, row := range t.Rows {
+	for i, row := range t.Rows {
 		for filterKey, filterValue := range filters {
 			if filterValue != config.ALL_CATEGORIES_OPTION {
 
@@ -132,12 +133,13 @@ rowLoop:
 			}
 		}
 		rows = append(rows, row)
+		rowsAsSingleStrings = append(rowsAsSingleStrings, t.RowsAsSingleStrings[i])
 	}
 
 	return &TableData{
 		Headers:             t.Headers,
 		Rows:                rows,
-		RowsAsSingleStrings: convertRowsToRowsAsSingleStrings(rows),
+		RowsAsSingleStrings: rowsAsSingleStrings,
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -112,19 +112,20 @@ func init() {
 	FetchCounter.increment()
 }
 
+// filterSplitRe splits state/partition fields on "+" or "," delimiters.
+var filterSplitRe = regexp.MustCompile("[,+]")
+
 // Applies a list of given filters to the data
 func (t *TableData) ApplyFilters(filters map[int]string) *TableData {
-	data := t.DeepCopy()
-
-	var rows [][]CellValue
+	rows := make([][]CellValue, 0, len(t.Rows))
 rowLoop:
-	for _, row := range data.Rows {
+	for _, row := range t.Rows {
 		for filterKey, filterValue := range filters {
 			if filterValue != config.ALL_CATEGORIES_OPTION {
 
 				// The filters we have are either by state (+-separated) or by partition (comma-separated). We split by both.
 				// Use Display() to get string representation for filtering
-				valuesInRowField := regexp.MustCompile("[,+]").Split(row[filterKey].Display(), -1)
+				valuesInRowField := filterSplitRe.Split(row[filterKey].Display(), -1)
 				if !slices.Contains(valuesInRowField, filterValue) {
 					continue rowLoop
 				}
@@ -134,7 +135,7 @@ rowLoop:
 	}
 
 	return &TableData{
-		Headers:             data.Headers,
+		Headers:             t.Headers,
 		Rows:                rows,
 		RowsAsSingleStrings: convertRowsToRowsAsSingleStrings(rows),
 	}

--- a/internal/view/app.go
+++ b/internal/view/app.go
@@ -60,6 +60,11 @@ type App struct {
 	// Command modal state
 	CommandModalOpen bool
 
+	// settingUpSortOptions is set true while setupSortSelectorOptions is populating
+	// the sort dropdown. This prevents applySortSelector's SetCurrentOption callback
+	// from flipping sortDirection or triggering a render during programmatic setup.
+	settingUpSortOptions bool
+
 	// Data  and providers
 	PartitionsData     *model.TableData
 	PartitionsProvider model.DataProvider[*model.TableData]
@@ -224,6 +229,11 @@ func (a *App) SetupViews() {
 			&a.SearchPattern,                // pointer to search string
 		)
 		a.Pages.AddPage(config.NODES_PAGE, a.NodesView.Grid, true, true)
+		a.NodesView.checkVisible = func() bool {
+			name, _ := a.Pages.GetFrontPage()
+			return name == config.NODES_PAGE
+		}
+		a.NodesView.stateChoiceFunc = func() string { return config.NodeStateCurrentChoice }
 	}
 
 	{ // Jobs View
@@ -238,6 +248,11 @@ func (a *App) SetupViews() {
 			&a.SearchPattern,                // pointer to search string
 		)
 		a.Pages.AddPage(config.JOBS_PAGE, a.JobsView.Grid, true, false)
+		a.JobsView.checkVisible = func() bool {
+			name, _ := a.Pages.GetFrontPage()
+			return name == config.JOBS_PAGE
+		}
+		a.JobsView.stateChoiceFunc = func() string { return config.JobStateCurrentChoice }
 	}
 
 	{
@@ -256,6 +271,10 @@ func (a *App) SetupViews() {
 			&a.SearchPattern,                // pointer to search string
 		)
 		a.Pages.AddPage(config.SACCTMGR_PAGE, a.SacctMgrView.Grid, true, false)
+		a.SacctMgrView.checkVisible = func() bool {
+			name, _ := a.Pages.GetFrontPage()
+			return name == config.SACCTMGR_PAGE
+		}
 
 		a.SacctView = NewStuiView(
 			"Jobs Accounting",
@@ -269,6 +288,11 @@ func (a *App) SetupViews() {
 		)
 
 		a.Pages.AddPage(config.SACCT_PAGE, a.SacctView.Grid, true, false)
+		a.SacctView.checkVisible = func() bool {
+			name, _ := a.Pages.GetFrontPage()
+			return name == config.SACCT_PAGE
+		}
+		a.SacctView.stateChoiceFunc = func() string { return config.JobStateCurrentChoice }
 	}
 
 	{ // Scheduler View

--- a/internal/view/bench_test.go
+++ b/internal/view/bench_test.go
@@ -94,13 +94,32 @@ func newBenchStuiView(td *model.TableData, searchPattern *string) *StuiView {
 	return sv
 }
 
-// BenchmarkStuiViewRender_Nodes measures a full Render() pass over 8 888 node rows.
+// BenchmarkStuiViewRender_Nodes measures Render() when state is unchanged (no-op path).
+// This is the common case in a running cluster between data refreshes.
 func BenchmarkStuiViewRender_Nodes(b *testing.B) {
 	td := buildSyntheticTableData(8888)
 	searchPattern := ""
 	sv := newBenchStuiView(td, &searchPattern)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		sv.Render()
+	}
+}
+
+// BenchmarkStuiViewRender_Nodes_Dirty measures a full Render() rebuild on every iteration
+// by toggling the sort direction so the render key always changes.
+func BenchmarkStuiViewRender_Nodes_Dirty(b *testing.B) {
+	td := buildSyntheticTableData(8888)
+	searchPattern := ""
+	sv := newBenchStuiView(td, &searchPattern)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Alternate sort direction each iteration so the key is always different.
+		if i%2 == 0 {
+			sv.sortDirection = SORT_ASC
+		} else {
+			sv.sortDirection = SORT_DESC
+		}
 		sv.Render()
 	}
 }

--- a/internal/view/bench_test.go
+++ b/internal/view/bench_test.go
@@ -1,0 +1,150 @@
+package view
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/antvirf/stui/internal/config"
+	"github.com/antvirf/stui/internal/model"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func init() {
+	config.ComputeConfigurations()
+}
+
+// benchProvider is a minimal DataProvider[*model.TableData] for benchmarks.
+type benchProvider struct {
+	data *model.TableData
+}
+
+func (p *benchProvider) Length() int                      { return p.data.Length() }
+func (p *benchProvider) Fetch() error                     { return nil }
+func (p *benchProvider) FetchIfStale(time.Duration) error { return nil }
+func (p *benchProvider) Data() *model.TableData           { return p.data.DeepCopy() }
+func (p *benchProvider) FilteredData() *model.TableData   { return p.data }
+func (p *benchProvider) LastUpdated() time.Time           { return time.Time{} }
+func (p *benchProvider) LastError() error                 { return nil }
+
+// buildSyntheticTableData creates a *model.TableData with nRows synthetic node rows
+// shaped to match config.NodeViewColumns (set up by init above).
+func buildSyntheticTableData(nRows int) *model.TableData {
+	cols := config.NodeViewColumns
+	nCols := len(*cols)
+
+	states := []string{"IDLE", "ALLOCATED", "DOWN", "DRAINED", "MIXED"}
+	partitions := []string{"general", "physics", "chemistry", "mathematics", "biology"}
+
+	rows := make([][]model.CellValue, nRows)
+	rowStrings := make([]string, nRows)
+
+	for i := range rows {
+		row := make([]model.CellValue, nCols)
+		for j, col := range *cols {
+			switch col.DisplayName {
+			case "NodeName":
+				row[j] = model.NewStringValue(fmt.Sprintf("node%05d", i))
+			case "Partitions":
+				row[j] = model.NewStringValue(partitions[i%len(partitions)])
+			case "State":
+				row[j] = model.NewStringValue(states[i%len(states)])
+			default:
+				row[j] = model.NewStringValue("N/A")
+			}
+		}
+		rows[i] = row
+
+		var sb strings.Builder
+		for _, c := range row {
+			sb.WriteString(c.Display())
+		}
+		rowStrings[i] = sb.String()
+	}
+
+	return &model.TableData{
+		Headers:             cols,
+		Rows:                rows,
+		RowsAsSingleStrings: rowStrings,
+	}
+}
+
+// newBenchStuiView creates a minimal StuiView suitable for render benchmarks.
+func newBenchStuiView(td *model.TableData, searchPattern *string) *StuiView {
+	sv := &StuiView{
+		Table:         tview.NewTable(),
+		provider:      &benchProvider{data: td},
+		data:          td,
+		sortColumn:    -1,
+		sortDirection: SORT_NONE,
+		searchEnabled: false,
+		searchPattern: searchPattern,
+		updateTitleFunction: func(string) *tview.Box {
+			return nil
+		},
+		errorNotificationFunction:     func(string) {},
+		dataStateNotificationFunction: func(string) {},
+	}
+	sv.Table.
+		SetBorders(false).
+		SetFixed(1, 0).
+		SetSelectable(true, false)
+	return sv
+}
+
+// BenchmarkStuiViewRender_Nodes measures a full Render() pass over 8 888 node rows.
+func BenchmarkStuiViewRender_Nodes(b *testing.B) {
+	td := buildSyntheticTableData(8888)
+	searchPattern := ""
+	sv := newBenchStuiView(td, &searchPattern)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sv.Render()
+	}
+}
+
+// BenchmarkStuiViewRender_WithSearch measures Render() with an active search pattern
+// (adds per-row regex matching and per-cell highlight tracking).
+func BenchmarkStuiViewRender_WithSearch(b *testing.B) {
+	td := buildSyntheticTableData(8888)
+	searchPattern := "IDLE"
+	sv := newBenchStuiView(td, &searchPattern)
+	sv.searchEnabled = true
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sv.Render()
+	}
+}
+
+// BenchmarkApplySortingToRows measures sorting 8 888 rows by string column.
+// A fresh copy of the row slice is made each iteration so that sort order
+// does not degrade across iterations.
+func BenchmarkApplySortingToRows(b *testing.B) {
+	td := buildSyntheticTableData(8888)
+	searchPattern := ""
+	sv := newBenchStuiView(td, &searchPattern)
+	sv.sortColumn = 0 // NodeName — string comparison
+	sv.sortDirection = SORT_ASC
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rows := make([][]model.CellValue, len(td.Rows))
+		copy(rows, td.Rows)
+		sv.ApplySortingToRows(&rows)
+	}
+}
+
+// BenchmarkColorizeTableCell measures the colorization function called once per
+// visible cell in every Render() pass.
+func BenchmarkColorizeTableCell(b *testing.B) {
+	cell := tview.NewTableCell("test-value")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Exercise all code paths: plain, selected, search-matched, colorized
+		colorizeTableCell(cell, false, false, false, tcell.ColorWhite)
+		colorizeTableCell(cell, true, false, false, tcell.ColorWhite)
+		colorizeTableCell(cell, false, true, false, tcell.ColorWhite)
+		colorizeTableCell(cell, false, false, true, tcell.ColorRed)
+	}
+}

--- a/internal/view/export_test.go
+++ b/internal/view/export_test.go
@@ -127,7 +127,7 @@ func TestGetVisibleRowsAsText(t *testing.T) {
 
 	t.Run("nil data returns nil", func(t *testing.T) {
 		nilView := &StuiView{data: nil}
-		hdrs := view.GetHeadersAsText()
+		hdrs := nilView.GetHeadersAsText()
 		rows := nilView.GetVisibleRowsAsText()
 		assert.Nil(t, hdrs)
 		assert.Nil(t, rows)

--- a/internal/view/selector_sort.go
+++ b/internal/view/selector_sort.go
@@ -31,6 +31,9 @@ func (a *App) SetupSortSelector() {
 }
 
 func (a *App) setupSortSelectorOptions(provider model.DataProvider[*model.TableData], selectedColumn int) {
+	a.settingUpSortOptions = true
+	defer func() { a.settingUpSortOptions = false }()
+
 	a.SortSelector.SetCurrentOption(selectedColumn)
 	a.SortSelector.SetOptions([]string{}, nil)
 	columns := provider.Data().Headers
@@ -56,6 +59,11 @@ func (a *App) setupSortSelectorOptions(provider model.DataProvider[*model.TableD
 
 func (a *App) applySortSelector(column int) func() {
 	return func() {
+		// Ignore programmatic SetCurrentOption calls during sort selector setup.
+		if a.settingUpSortOptions {
+			return
+		}
+
 		view := a.GetCurrentStuiView()
 		if view == nil {
 			return

--- a/internal/view/stuiview.go
+++ b/internal/view/stuiview.go
@@ -149,6 +149,9 @@ func (s *StuiView) ApplySortingToRows(rows *[][]model.CellValue) {
 }
 
 func (s *StuiView) GetHeadersAsText() []string {
+	if s.data == nil {
+		return nil
+	}
 	rawHeaders := *s.data.Headers
 	headers := make([]string, len(rawHeaders))
 	for i, h := range rawHeaders {

--- a/internal/view/stuiview.go
+++ b/internal/view/stuiview.go
@@ -249,7 +249,7 @@ func (s *StuiView) Render() {
 
 		// Pre-calculate row-level search matches (used for highlights) for efficiency
 		var matches [][]int
-		if s.searchEnabled && *s.searchPattern != "" && !config.DisableSearchHighlight {
+		if s.searchEnabled && *s.searchPattern != "" && !config.DisableSearchHighlight && searchPatternRegex != nil {
 			var sb strings.Builder
 			for _, c := range rowData {
 				sb.WriteString(c.Display())

--- a/internal/view/stuiview.go
+++ b/internal/view/stuiview.go
@@ -14,6 +14,37 @@ import (
 	"github.com/rivo/tview"
 )
 
+// renderStateKey captures everything that determines what Render() would draw.
+// If it matches the previous render's key, the rebuild can be skipped entirely.
+// All fields are O(1) to compute - no hashing of row data.
+type renderStateKey struct {
+	dataLastUpdated  time.Time
+	filteredRowCount int
+	filter           string // partition / entity filter applied to this view
+	hasError         bool
+	searchEnabled    bool
+	searchPattern    string
+	sortColumn       int
+	sortDirection    int
+	selectionLen     int
+	stateChoice      string // categorical state filter (node/job state selector)
+}
+
+func computeRenderKey(lastUpdated time.Time, filteredRowCount int, filter string, hasError, searchEnabled bool, searchPattern string, sortColumn, sortDirection, selectionLen int, stateChoice string) renderStateKey {
+	return renderStateKey{
+		dataLastUpdated:  lastUpdated,
+		filteredRowCount: filteredRowCount,
+		filter:           filter,
+		hasError:         hasError,
+		searchEnabled:    searchEnabled,
+		searchPattern:    searchPattern,
+		sortColumn:       sortColumn,
+		sortDirection:    sortDirection,
+		selectionLen:     selectionLen,
+		stateChoice:      stateChoice,
+	}
+}
+
 func NewStuiView(
 	title string,
 	provider model.DataProvider[*model.TableData],
@@ -97,9 +128,31 @@ type StuiView struct {
 	headerClickFunction           func(int) *tview.DropDown
 
 	// Data components
-	provider model.DataProvider[*model.TableData]
-	data     *model.TableData
-	filter   string
+	provider      model.DataProvider[*model.TableData]
+	data          *model.TableData
+	filter        string
+	lastRenderKey renderStateKey
+
+	// checkVisible, if set, is called at the start of Render(). When it returns
+	// false the method returns immediately without rebuilding the tview table.
+	// lastRenderKey is NOT updated, so the next Render() call after the page
+	// becomes visible will detect any stale state and do a full rebuild then.
+	checkVisible func() bool
+
+	// stateChoiceFunc, if set, returns the categorical state-filter value for
+	// this view (e.g. config.NodeStateCurrentChoice for the nodes view). Using
+	// a per-view func avoids cross-view cache invalidation: changing the job
+	// state selector will not force a re-render of the nodes view and vice versa.
+	stateChoiceFunc func() string
+}
+
+// stateChoice returns the current categorical state-filter value for this view,
+// or an empty string if no state filter applies.
+func (s *StuiView) stateChoice() string {
+	if s.stateChoiceFunc == nil {
+		return ""
+	}
+	return s.stateChoiceFunc()
 }
 
 func (s *StuiView) SetFilter(filter string) {
@@ -182,9 +235,22 @@ func (s *StuiView) GetVisibleRowsAsText() (rows [][]string) {
 }
 
 func (s *StuiView) Render() {
+	// Skip the expensive tview table rebuild when this page is not visible.
+	// lastRenderKey is intentionally NOT updated here so that the first
+	// Render() after the page becomes active will detect any pending changes.
+	if s.checkVisible != nil && !s.checkVisible() {
+		return
+	}
+
 	startTime := time.Now()
 	s.data = s.provider.FilteredData()
 	filterDataTime := time.Since(startTime).Milliseconds()
+
+	key := computeRenderKey(s.provider.LastUpdated(), s.data.Length(), s.filter, s.provider.LastError() != nil, s.searchEnabled, *s.searchPattern, s.sortColumn, s.sortDirection, len(s.Selection), s.stateChoice())
+	if key == s.lastRenderKey {
+		return
+	}
+	s.lastRenderKey = key
 
 	s.Table.Clear()
 

--- a/makefile
+++ b/makefile
@@ -138,6 +138,31 @@ stop-cluster:
 mock: config-cluster run-cluster setup-sacct launch-jobs
 
 
+## PERFORMANCE BENCHMARKS
+
+BENCH_RESULTS_DIR := testing/perf-results
+
+.PHONY: perf-tests perf-compare
+
+perf-tests:
+	mkdir -p $(BENCH_RESULTS_DIR)
+	go test -bench=. -benchmem -benchtime=3s -count=3 \
+		./internal/model/... ./internal/view/... \
+		| tee $(BENCH_RESULTS_DIR)/bench-$$(date +%Y%m%d-%H%M%S).txt
+	@echo "Results saved to $(BENCH_RESULTS_DIR)/. Run 'make perf-compare' to diff against previous run."
+
+perf-compare:
+	@FILES=$$(ls -t $(BENCH_RESULTS_DIR)/*.txt 2>/dev/null); \
+	COUNT=$$(echo "$$FILES" | wc -w); \
+	if [ "$$COUNT" -lt 2 ]; then \
+		echo "Need at least 2 result files to compare. Run 'make perf-tests' twice."; \
+	else \
+		PREV=$$(echo "$$FILES" | sed -n '2p'); \
+		CURR=$$(echo "$$FILES" | sed -n '1p'); \
+		echo "Comparing $$PREV vs $$CURR"; \
+		go run golang.org/x/perf/cmd/benchstat@latest "$$PREV" "$$CURR"; \
+	fi
+
 ## TESTING UTILITIES
 
 generate-test-data:

--- a/testing/perf-results/bench-20260501-180330.txt
+++ b/testing/perf-results/bench-20260501-180330.txt
@@ -1,0 +1,42 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	      92	  34344932 ns/op	44755861 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	      93	  35292541 ns/op	44755794 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     103	  35776937 ns/op	44755811 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     664	   5463211 ns/op	 7219996 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     668	   5372350 ns/op	 7219996 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     662	   5399392 ns/op	 7219991 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     208	  17166522 ns/op	10664540 B/op	  206001 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     210	  17341482 ns/op	10664539 B/op	  206001 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     207	  17803705 ns/op	10664529 B/op	  206001 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     450	   7996435 ns/op	 4021671 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     447	   7984334 ns/op	 4021660 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     450	   7904436 ns/op	 4021673 B/op	   98544 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     414	   8647768 ns/op	 5665907 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     415	   8687714 ns/op	 5665898 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     404	   8877311 ns/op	 5665889 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     835	   4361680 ns/op	  674524 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     819	   4423852 ns/op	  674777 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     782	   4355445 ns/op	  674379 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	83.122s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8        	      74	  50770997 ns/op	33600811 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      84	  38471417 ns/op	33608857 B/op	  400060 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      79	  38245394 ns/op	33608398 B/op	  400059 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     256	  13467398 ns/op	 7489540 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     265	  14487225 ns/op	 7492300 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     242	  13980197 ns/op	 7488726 B/op	   89008 allocs/op
+BenchmarkApplySortingToRows-8          	   22107	    160117 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   23110	    152593 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   22998	    154207 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8           	24985569	       120.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	30408306	       120.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28241781	       126.3 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	54.077s

--- a/testing/perf-results/bench-20260501-180547.txt
+++ b/testing/perf-results/bench-20260501-180547.txt
@@ -1,0 +1,42 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	     104	  34265613 ns/op	44755808 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	      91	  34231605 ns/op	44755807 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	      92	  34341843 ns/op	44755802 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     660	   5385831 ns/op	 7219996 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     674	   5358672 ns/op	 7219994 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     676	   5890252 ns/op	 7219995 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     201	  17725024 ns/op	10664554 B/op	  206002 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     190	  17795662 ns/op	10664523 B/op	  206001 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     201	  17656090 ns/op	10664531 B/op	  206001 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     439	   8097498 ns/op	 4021667 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     447	   8179657 ns/op	 4021671 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     426	   8208292 ns/op	 4021655 B/op	   98544 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     400	   8921561 ns/op	 5665895 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     408	   8934860 ns/op	 5665900 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     376	   9293664 ns/op	 5665901 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     804	   4487396 ns/op	  674485 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     794	   4732038 ns/op	  674548 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     811	   4614732 ns/op	  674384 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	84.117s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8        	      76	  40503134 ns/op	33600388 B/op	  400057 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      87	  37962426 ns/op	33597653 B/op	  400057 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      92	  38062861 ns/op	33591588 B/op	  400057 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     261	  13566792 ns/op	 7491358 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     264	  13576866 ns/op	 7485322 B/op	   89007 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     256	  13750783 ns/op	 7491401 B/op	   89009 allocs/op
+BenchmarkApplySortingToRows-8          	   23403	    155184 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   23217	    154880 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   23319	    153707 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8           	25057238	       126.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28776012	       123.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28168423	       127.0 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	56.406s

--- a/testing/perf-results/bench-20260501-180808.txt
+++ b/testing/perf-results/bench-20260501-180808.txt
@@ -1,0 +1,42 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	      93	  35566541 ns/op	44755802 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     103	  34700546 ns/op	44755814 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	      90	  34704439 ns/op	44755812 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     655	   5339468 ns/op	 7219989 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     657	   5357965 ns/op	 7219995 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     669	   5438391 ns/op	 7219997 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     198	  18218933 ns/op	10664514 B/op	  206001 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     198	  18721150 ns/op	10664522 B/op	  206001 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     200	  17660062 ns/op	10664526 B/op	  206001 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     435	   8200742 ns/op	 4021676 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     434	   8102279 ns/op	 4021656 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     439	   8217664 ns/op	 4021660 B/op	   98544 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     403	   8895046 ns/op	 5665891 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     403	   9045475 ns/op	 5665899 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     387	   9020010 ns/op	 5665891 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     799	   4469228 ns/op	  674031 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     807	   4441524 ns/op	  674390 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     796	   4390758 ns/op	  674314 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	83.588s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8        	      96	  37774642 ns/op	33598145 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      96	  38768422 ns/op	33600267 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      94	  37655177 ns/op	33584573 B/op	  400055 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     266	  13589066 ns/op	 7490218 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     260	  13881596 ns/op	 7494865 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     261	  13620912 ns/op	 7488185 B/op	   89008 allocs/op
+BenchmarkApplySortingToRows-8          	   23431	    155173 ns/op	  221282 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   22401	    163073 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   21512	    162731 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8           	23624299	       133.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	27476556	       124.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28634158	       121.8 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	61.047s

--- a/testing/perf-results/bench-20260501-181033.txt
+++ b/testing/perf-results/bench-20260501-181033.txt
@@ -1,0 +1,42 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	      93	  34959669 ns/op	44755808 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     104	  35632028 ns/op	44755804 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     103	  34452102 ns/op	44755800 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     668	   5353217 ns/op	 7219991 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     662	   5385162 ns/op	 7219994 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     669	   5366000 ns/op	 7219999 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     201	  17627443 ns/op	10664562 B/op	  206002 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     201	  18131186 ns/op	10664555 B/op	  206002 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     200	  17781660 ns/op	10664553 B/op	  206002 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     446	   8207030 ns/op	 4021651 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     444	   8165839 ns/op	 4021665 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     440	   8299744 ns/op	 4021663 B/op	   98544 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     408	   8940758 ns/op	 5665882 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     402	   9048995 ns/op	 5665904 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     398	   8955011 ns/op	 5665904 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     783	   4451726 ns/op	  674996 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     802	   4500096 ns/op	  674351 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     775	   4520235 ns/op	  674395 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	86.987s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8        	      91	  39198788 ns/op	33600316 B/op	  400057 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      79	  38377074 ns/op	33600480 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      90	  41769637 ns/op	33606145 B/op	  400059 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     222	  16813794 ns/op	 7491826 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     183	  18990956 ns/op	 7486393 B/op	   89008 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     234	  13820351 ns/op	 7491411 B/op	   89009 allocs/op
+BenchmarkApplySortingToRows-8          	   23286	    156993 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   23126	    177995 ns/op	  221282 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   21942	    183313 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8           	23132082	       132.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	27859099	       130.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	25889275	       139.0 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	56.450s

--- a/testing/perf-results/bench-20260501-181257.txt
+++ b/testing/perf-results/bench-20260501-181257.txt
@@ -1,0 +1,42 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	      61	  57113259 ns/op	44755918 B/op	   88906 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	      67	  54677274 ns/op	44755819 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	      66	  54565698 ns/op	44755815 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     426	   8718869 ns/op	 7219996 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     424	   8672604 ns/op	 7220004 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     412	   8026303 ns/op	 7220010 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     133	  27703501 ns/op	10664551 B/op	  206002 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     122	  27890739 ns/op	10664586 B/op	  206002 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     120	  27774620 ns/op	10664560 B/op	  206002 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     295	  12981535 ns/op	 4021672 B/op	   98545 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     270	  12844274 ns/op	 4021674 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     274	  12951302 ns/op	 4021691 B/op	   98545 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     357	  10276887 ns/op	 5665894 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     386	   9439209 ns/op	 5665899 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     399	   9021621 ns/op	 5665904 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     781	   4560081 ns/op	  674524 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     777	   4443229 ns/op	  674624 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     794	   4426595 ns/op	  674177 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	93.090s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8        	      94	  37872408 ns/op	33600062 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      80	  37834220 ns/op	33590609 B/op	  400056 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      90	  38198946 ns/op	33598245 B/op	  400056 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     260	  13448906 ns/op	 7487272 B/op	   89008 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     259	  13587045 ns/op	 7491785 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     262	  13492244 ns/op	 7493269 B/op	   89009 allocs/op
+BenchmarkApplySortingToRows-8          	   24933	    206181 ns/op	  221282 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   14718	    250630 ns/op	  221282 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   20259	    165398 ns/op	  221282 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8           	24489512	       129.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	27393444	       129.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	27959768	       126.5 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	59.485s

--- a/testing/perf-results/bench-20260501-181530.txt
+++ b/testing/perf-results/bench-20260501-181530.txt
@@ -1,0 +1,42 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	      93	  35130037 ns/op	44755804 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	      85	  35460192 ns/op	44755801 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     100	  36233705 ns/op	44755800 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     652	   5436266 ns/op	 7219992 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     573	   9633259 ns/op	 7219997 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     517	   5924889 ns/op	 7219996 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     178	  20202646 ns/op	10664532 B/op	  206001 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     175	  18149113 ns/op	10664498 B/op	  206001 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     195	  18122599 ns/op	10664536 B/op	  206001 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     429	   8339440 ns/op	 4021679 B/op	   98545 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     428	   8972865 ns/op	 4021668 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     429	   8327361 ns/op	 4021667 B/op	   98544 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     399	  10983696 ns/op	 5665896 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     370	   9208443 ns/op	 5665894 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     385	   9620226 ns/op	 5665896 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     795	   4577525 ns/op	  674176 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     747	   4644380 ns/op	  674836 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     768	   4749031 ns/op	  674354 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	92.637s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8        	      85	  39320644 ns/op	33601217 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      90	  39068236 ns/op	33597146 B/op	  400057 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      76	  40951613 ns/op	33600256 B/op	  400059 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     258	  13973505 ns/op	 7491249 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     259	  13877369 ns/op	 7490629 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     258	  14723296 ns/op	 7490492 B/op	   89008 allocs/op
+BenchmarkApplySortingToRows-8          	   21729	    167505 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   19752	    185373 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   22472	    170054 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8           	24584083	       125.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	27986706	       125.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28166505	       127.8 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	57.421s

--- a/testing/perf-results/bench-20260501-184555.txt
+++ b/testing/perf-results/bench-20260501-184555.txt
@@ -1,0 +1,42 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	      87	  34574229 ns/op	44755810 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     105	  34311456 ns/op	44755806 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	      87	  34841799 ns/op	44755808 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     663	   5388649 ns/op	 7219995 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     666	   5405125 ns/op	 7219996 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     656	   5370139 ns/op	 7219995 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     408	   8539194 ns/op	 4242931 B/op	   98546 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     418	   8503377 ns/op	 4242920 B/op	   98546 allocs/op
+BenchmarkApplyFilters_Nodes-8           	     426	   8883969 ns/op	 4242922 B/op	   98546 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     432	   8442975 ns/op	 4021655 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     438	   8225704 ns/op	 4021667 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     442	   8318352 ns/op	 4021660 B/op	   98544 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     283	  10796810 ns/op	 5665908 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     391	  10081232 ns/op	 5665899 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     331	   9786599 ns/op	 5665903 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     811	   4490190 ns/op	  674383 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     756	   4522844 ns/op	  674374 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     830	   4363931 ns/op	  674222 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	80.757s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8        	      94	  37825872 ns/op	33592804 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      82	  37493952 ns/op	33584092 B/op	  400056 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      81	  39595714 ns/op	33598604 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     260	  13680022 ns/op	 7491569 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     265	  13521044 ns/op	 7487661 B/op	   89008 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     261	  13853556 ns/op	 7493806 B/op	   89009 allocs/op
+BenchmarkApplySortingToRows-8          	   23444	    156427 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   23179	    156370 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   23148	    154890 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8           	25271887	       129.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28340547	       121.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28880684	       125.0 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	54.174s

--- a/testing/perf-results/bench-20260501-190132.txt
+++ b/testing/perf-results/bench-20260501-190132.txt
@@ -1,0 +1,42 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	      92	  33648697 ns/op	44755861 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     105	  34303320 ns/op	44755818 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     106	  33845950 ns/op	44755806 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     667	   5400737 ns/op	 7219993 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     666	   5533631 ns/op	 7219988 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     658	   5459895 ns/op	 7219989 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	    6439	    478770 ns/op	  368705 B/op	       3 allocs/op
+BenchmarkApplyFilters_Nodes-8           	    7556	    467878 ns/op	  368706 B/op	       3 allocs/op
+BenchmarkApplyFilters_Nodes-8           	    7509	    475786 ns/op	  368706 B/op	       3 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     447	   7937164 ns/op	 4021663 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     445	   8157575 ns/op	 4021655 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     448	   8021276 ns/op	 4021664 B/op	   98544 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     391	   8701120 ns/op	 5665899 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     403	   8667796 ns/op	 5665900 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     408	   8642838 ns/op	 5665898 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     807	   4393797 ns/op	  674571 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     842	   4294369 ns/op	  674336 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     826	   4355011 ns/op	  674538 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	80.310s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8        	      97	  37060645 ns/op	33592812 B/op	  400057 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      84	  37073083 ns/op	33592971 B/op	  400056 allocs/op
+BenchmarkStuiViewRender_Nodes-8        	      94	  38430140 ns/op	33599508 B/op	  400058 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     262	  13537708 ns/op	 7493622 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     261	  13647903 ns/op	 7491517 B/op	   89009 allocs/op
+BenchmarkStuiViewRender_WithSearch-8   	     265	  13570452 ns/op	 7488964 B/op	   89008 allocs/op
+BenchmarkApplySortingToRows-8          	   23259	    163952 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   22162	    164261 ns/op	  221282 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8          	   20985	    167837 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8           	24653521	       129.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28168704	       128.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8           	28418996	       121.2 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	57.695s

--- a/testing/perf-results/bench-20260501-221309.txt
+++ b/testing/perf-results/bench-20260501-221309.txt
@@ -1,0 +1,45 @@
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/model
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkParseScontrolOutput_Nodes-8    	      94	  33793346 ns/op	44755809 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     105	  34007127 ns/op	44755806 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Nodes-8    	     106	  33848327 ns/op	44755816 B/op	   88905 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     664	   5378019 ns/op	 7220000 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     672	   5383310 ns/op	 7219989 B/op	    8207 allocs/op
+BenchmarkParseScontrolOutput_Jobs-8     	     658	   5497381 ns/op	 7219996 B/op	    8207 allocs/op
+BenchmarkApplyFilters_Nodes-8           	    6919	    515131 ns/op	  368706 B/op	       3 allocs/op
+BenchmarkApplyFilters_Nodes-8           	    7155	    476964 ns/op	  368706 B/op	       3 allocs/op
+BenchmarkApplyFilters_Nodes-8           	    7420	    464438 ns/op	  368706 B/op	       3 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     456	   7832100 ns/op	 4021656 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     458	   7891943 ns/op	 4021673 B/op	   98544 allocs/op
+BenchmarkConvertRowsToSingleStrings-8   	     450	   7957327 ns/op	 4021662 B/op	   98544 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     410	   8577871 ns/op	 5665904 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     416	   9025658 ns/op	 5665891 B/op	  107437 allocs/op
+BenchmarkDeepCopy_Nodes-8               	     325	   9758483 ns/op	 5665884 B/op	  107437 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     824	   4272470 ns/op	  674228 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     835	   4263431 ns/op	  674349 B/op	      18 allocs/op
+BenchmarkApplyRegexSearchFilter-8       	     831	   4254629 ns/op	  674266 B/op	      18 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/model	80.568s
+goos: linux
+goarch: amd64
+pkg: github.com/antvirf/stui/internal/view
+cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
+BenchmarkStuiViewRender_Nodes-8         	54733923	        62.77 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStuiViewRender_Nodes-8         	56037946	        63.07 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStuiViewRender_Nodes-8         	56809923	        63.13 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStuiViewRender_Nodes_Dirty-8   	      80	  41151693 ns/op	33597474 B/op	  400057 allocs/op
+BenchmarkStuiViewRender_Nodes_Dirty-8   	      85	  37072703 ns/op	33604612 B/op	  400059 allocs/op
+BenchmarkStuiViewRender_Nodes_Dirty-8   	      84	  36522551 ns/op	33596895 B/op	  400057 allocs/op
+BenchmarkStuiViewRender_WithSearch-8    	57068601	        60.84 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStuiViewRender_WithSearch-8    	59199523	        62.00 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStuiViewRender_WithSearch-8    	58782260	        62.90 ns/op	       0 B/op	       0 allocs/op
+BenchmarkApplySortingToRows-8           	   26085	    158131 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8           	   19540	    163424 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkApplySortingToRows-8           	   21828	    155673 ns/op	  221283 B/op	       4 allocs/op
+BenchmarkColorizeTableCell-8            	25360066	       124.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8            	28457923	       121.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkColorizeTableCell-8            	29233314	       120.8 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/antvirf/stui/internal/view	71.651s


### PR DESCRIPTION
See individual commits for details.

Also adds a `make perf-tests` and make `perf-compare` to be able to iterate on performance metrics with real data.

Of the ~800 line diff, only about ~400 are `.go` code, the other half is perf test results stored for reference. Of the remaining ~400, most of that is in new tests/bench gode, the actual fixes/minor changes to achieve perf gains are mostly tiny.