### PR TITLE
feat(sacctmgr): expand various entity tables with "withX" modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stui` - Slurm Terminal User Interface for managing clusters
 
 ![go report](https://goreportcard.com/badge/github.com/antvirf/stui)
-![loc](https://img.shields.io/badge/lines%20of%20code-7909-blue)
+![loc](https://img.shields.io/badge/lines%20of%20code-7923-blue)
 ![size](https://img.shields.io/badge/binary%20size-5%2E8M-blue)
 
 *Like [k9s](https://k9scli.io/), but for Slurm clusters.* `stui` makes interacting with Slurm clusters intuitive and fast for everyone, without getting in the way of more experienced users.

--- a/internal/model/constants.go
+++ b/internal/model/constants.go
@@ -86,10 +86,10 @@ var (
 
 	// https://slurm.schedmd.com/sacctmgr.html
 	SACCTMGR_ENTITY_COLUMN_CONFIGS = map[string]string{
-		"Account":                "Account,Org,Descr",
+		"Account":                "Account,Org,Descr,Coord Accounts",
 		"Association":            "Cluster,Account,User,Partition,Share,QOS,Def QOS,Priority,GrpJobs,GrpTRES,GrpSubmit,GrpWall,GrpTRESMins,MaxJobs,MaxTRES,MaxTRESPerNode,MaxSubmit,MaxWall,MaxTRESMins,GrpTRESRunMins",
 		"Association tree":       "Cluster,Account,User,Partition,Share,QOS,Def QOS,Priority,GrpJobs,GrpTRES,GrpSubmit,GrpWall,GrpTRESMins,MaxJobs,MaxTRES,MaxTRESPerNode,MaxSubmit,MaxWall,MaxTRESMins,GrpTRESRunMins",
-		"Cluster":                "Cluster,ControlHost,ControlPort,RPC,Share,QOS,Def QOS,GrpJobs,GrpTRES,GrpSubmit,MaxJobs,MaxTRES,MaxSubmit,MaxWall",
+		"Cluster":                "Cluster,ControlHost,ControlPort,RPC,Share,QOS,Def QOS,GrpJobs,GrpTRES,GrpSubmit,MaxJobs,MaxTRES,MaxSubmit,MaxWall,Federation,ID,Features,FedState",
 		"Event":                  "Cluster,NodeName,TimeStart,TimeEnd,State,Reason,User",
 		"Federation":             "ID,Federation,Cluster,Features,FedState",
 		"Problem":                "Cluster,Account,User,Problem",
@@ -97,9 +97,16 @@ var (
 		"Resource":               "Name,Server,Type,Count,LastConsumed,Allocated,ServerType,Flags",
 		"Reservation":            "Name,Cluster,TRES,TimeStart,TimeEnd,UnusedWall",
 		SACCT_RUNAWAYJOBS_ENTITY: "ID,Name,State,Partition,Cluster,TimeEnd,TimeStart",
-		"Transaction":            "Time,Action,Actor,Where,Info",
+		"Transaction":            "Time,Action,Actor,Where,User,Account,Cluster,Info",
 		"TRES":                   "ID,Type,Name",
-		"User":                   "User,Def Acct,Def WCKey,Admin",
+		"User":                   "User,Def Acct,Def WCKey,Admin,Coord Accounts",
+	}
+
+	SACCTMGR_ENTITY_EXTRA_COMMAND_OPTIONS = map[string]string{
+		"Account":     "WithCoord",
+		"Cluster":     "WithFed",
+		"Transaction": "WithAssoc",
+		"User":        "WithCoord",
 	}
 
 	SACCTMGR_ENTITY_TABLES_WITH_NO_CLEAR_ID = []string{

--- a/internal/model/provider_sacctmgr.go
+++ b/internal/model/provider_sacctmgr.go
@@ -31,8 +31,15 @@ func (p *SacctMgrProvider) Fetch() error {
 		columns = append(columns, config.ColumnConfig{RawName: key, DisplayName: key})
 	}
 
+	extraCommandOptions, extraCommandExists := SACCTMGR_ENTITY_EXTRA_COMMAND_OPTIONS[config.SacctMgrCurrentEntity]
+	if extraCommandExists {
+		extraCommandOptions = fmt.Sprintf(" %s", extraCommandOptions)
+	} else {
+		extraCommandOptions = ""
+	}
+
 	rawData, err := getSacctMgrDataWithTimeout(
-		fmt.Sprintf("show %s --parsable2", config.SacctMgrCurrentEntity),
+		fmt.Sprintf("show %s%s --parsable2", config.SacctMgrCurrentEntity, extraCommandOptions),
 		config.RequestTimeout,
 		&columns,
 		false, // For sacctmgr we don't compute column widths for now.

--- a/testing/sacct-setup.sh
+++ b/testing/sacct-setup.sh
@@ -26,6 +26,10 @@ sacm add qos sparecapacity=5
 cat testing/mock-cluster-slurmconf.conf  | grep PartitionName | cut -d= -f2 | cut -d' ' -f1 | \
         xargs -I{} sacm create account name={} parent=science 
 
+sacm create user name=johndoe cluster=stui-test-cluster account=mathematics
+sacm create user name=jimdoe cluster=stui-test-cluster account=mathematics
+sacm create user name=janedoe cluster=stui-test-cluster account=chemistry
+
 # account for John Doe in each department
 cat testing/mock-cluster-slurmconf.conf  | grep PartitionName | cut -d= -f2 | cut -d' ' -f1 | \
         xargs -I{} sacm create user name=johndoe cluster=stui-test-cluster account={} 


### PR DESCRIPTION
## What does this change do?
feat(sacctmgr): expand various entity tables with "withX" modifiers

This includes: coordinators (now shown in account and user view), associations (now shown in transaction view) and federations (now shown in cluster view).

Closes https://github.com/Antvirf/stui/issues/90

## How has the change been tested?
Tested on Slurm 25.05.03

## Checklist
- [x] Change has been tested
- [x] Helpers/keybinds lists have been updated
- [x] Docs have been updated, if relevant
